### PR TITLE
add alias for old url path

### DIFF
--- a/content/post/100-days-of-code.md
+++ b/content/post/100-days-of-code.md
@@ -8,6 +8,7 @@ cover = "/images/2018/01/Screen-Shot-2018-01-14-at-4.52.19-PM.png"
 slug = "100-days-of-code"
 tags = ["Python", "golang", "Java", "C", "automation"]
 title = "100 Days of Code"
+aliases = ["/100-days-of-code/"]
 
 +++
 

--- a/content/post/a-brief-comparison-of-ipv4-and-ipv6.md
+++ b/content/post/a-brief-comparison-of-ipv4-and-ipv6.md
@@ -8,6 +8,7 @@ cover = "/images/2018/01/Screen-Shot-2018-01-27-at-3.53.00-PM.png"
 slug = "a-brief-comparison-of-ipv4-and-ipv6"
 tags = ["IPv6", "IPv4", "network"]
 title = "A Brief Comparison of IPv4 and IPv6"
+aliases = ["/a-brief-comparison-of-ipv4-and-ipv6/"]
 
 +++
 

--- a/content/post/aws-certified-developer-associate.md
+++ b/content/post/aws-certified-developer-associate.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/aws-Developer-Associate.jpg"
 slug = "aws-certified-developer-associate"
 tags = ["AWS"]
 title = "AWS Certified Developer – Associate"
+aliases = ["/aws-certified-developer-associate/"]
 
 +++
 

--- a/content/post/aws-certified-sysops-administrator-associate.md
+++ b/content/post/aws-certified-sysops-administrator-associate.md
@@ -8,6 +8,7 @@ cover = "/images/2017/11/aws-certified-sysops-adminstrator-associate-croma-campu
 slug = "aws-certified-sysops-administrator-associate"
 tags = ["AWS"]
 title = "AWS Certified SysOps Administrator – Associate"
+aliases = ["/aws-certified-sysops-administrator-associate/"]
 
 +++
 

--- a/content/post/aws-codestar-challenge.md
+++ b/content/post/aws-codestar-challenge.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/codestar-example-dashboard.png"
 slug = "aws-codestar-challenge"
 tags = ["AWS", "automation", "Python"]
 title = "AWS CodeStar Challenge"
+aliases = ["/aws-codestar-challenge/"]
 
 +++
 

--- a/content/post/aws-solutions-architect-associate.md
+++ b/content/post/aws-solutions-architect-associate.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/aws-certified-solutions-architect-associate.jpg"
 slug = "aws-solutions-architect-associate"
 tags = ["AWS"]
 title = "AWS Certified Solutions Architect - Associate"
+aliases = ["/aws-solutions-architect-associate/"]
 
 +++
 

--- a/content/post/black-hat-python.md
+++ b/content/post/black-hat-python.md
@@ -8,6 +8,7 @@ cover = "/images/2020/04/bhp.jpg"
 slug = "black-hat-python"
 tags = ["Python", "offsec", "security", "network", "pentesting", "tshark", "wireshark", "HTTP"]
 title = "Black Hat Python"
+aliases = ["/black-hat-python/"]
 
 +++
 

--- a/content/post/books-suggested-by-a-mentor-plus-one.md
+++ b/content/post/books-suggested-by-a-mentor-plus-one.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/sam-at-the-citadel.jpg"
 slug = "books-suggested-by-a-mentor-plus-one"
 tags = ["books"]
 title = "Books Suggested by a Mentor, Plus One"
+aliases = ["/books-suggested-by-a-mentor-plus-one/"]
 
 +++
 

--- a/content/post/books-worth-a-look.md
+++ b/content/post/books-worth-a-look.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/vintage-books-wallpaper-desktop-picture.jpg"
 slug = "books-worth-a-look"
 tags = ["books"]
 title = "Books Worth a Look"
+aliases = ["/books-worth-a-look/"]
 
 +++
 

--- a/content/post/building-hashicorp-vault-in-oci-part-i.md
+++ b/content/post/building-hashicorp-vault-in-oci-part-i.md
@@ -8,6 +8,7 @@ cover = "/images/2018/10/Screen-Shot-2018-10-09-at-1.17.31-PM-1.png"
 slug = "building-hashicorp-vault-in-oci-part-i"
 tags = ["OCI", "terraform", "cloud", "vault", "automation"]
 title = "Building Hashicorp Vault in OCI - Part I"
+aliases = ["/building-hashicorp-vault-in-oci-part-i/"]
 
 +++
 

--- a/content/post/building-hashicorp-vault-in-oci-part-ii.md
+++ b/content/post/building-hashicorp-vault-in-oci-part-ii.md
@@ -8,6 +8,7 @@ cover = "/images/2018/11/Screen-Shot-2018-10-09-at-1.17.31-PM.png"
 slug = "building-hashicorp-vault-in-oci-part-ii"
 tags = ["OCI", "terraform", "cloud", "vault", "automation", "consul"]
 title = "Building Hashicorp Vault in OCI - Part II"
+aliases = ["/building-hashicorp-vault-in-oci-part-ii/"]
 
 +++
 

--- a/content/post/building-hashicorp-vault-in-oci-part-iii.md
+++ b/content/post/building-hashicorp-vault-in-oci-part-iii.md
@@ -8,6 +8,7 @@ cover = "/images/2018/11/Screen-Shot-2018-10-09-at-1.17.31-PM-1.png"
 slug = "building-hashicorp-vault-in-oci-part-iii"
 tags = ["OCI", "terraform", "consul", "vault", "cloud", "automation"]
 title = "Building Hashicorp Vault in OCI - Part III"
+aliases = ["/building-hashicorp-vault-in-oci-part-iii/"]
 
 +++
 

--- a/content/post/building-openstack-containers-with-kolla.md
+++ b/content/post/building-openstack-containers-with-kolla.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-kolla.jpeg"
 slug = "building-openstack-containers-with-kolla"
 tags = ["OpenStack", "containers"]
 title = "Building OpenStack Containers with Kolla"
+aliases = ["/building-openstack-containers-with-kolla/"]
 
 +++
 

--- a/content/post/certified-kubernetes-administrator.md
+++ b/content/post/certified-kubernetes-administrator.md
@@ -8,6 +8,7 @@ cover = "/images/2018/12/logo_cka.png"
 slug = "certified-kubernetes-administrator"
 tags = ["kubernetes", "certification", "CNCF", "containers", "Docker"]
 title = "Certified Kubernetes Administrator"
+aliases = ["/certified-kubernetes-administrator/"]
 
 +++
 

--- a/content/post/clustering-galera-on-single-stack-ipv6.md
+++ b/content/post/clustering-galera-on-single-stack-ipv6.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/mariadb-galera.jpg"
 slug = "clustering-galera-on-single-stack-ipv6"
 tags = ["OpenStack", "IPv6"]
 title = "Clustering Galera on Single Stack IPv6"
+aliases = ["/clustering-galera-on-single-stack-ipv6/"]
 
 +++
 

--- a/content/post/clustering-rabbitmq-on-ipv6-only-with-openstack-ocata.md
+++ b/content/post/clustering-rabbitmq-on-ipv6-only-with-openstack-ocata.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/rabbitmq-clustering.jpg"
 slug = "clustering-rabbitmq-on-ipv6-only-with-openstack-ocata"
 tags = ["OpenStack", "IPv6", "availability"]
 title = "Clustering RabbitMQ on IPv6 with OpenStack Ocata"
+aliases = ["/clustering-rabbitmq-on-ipv6-only-with-openstack-ocata/"]
 
 +++
 

--- a/content/post/deploying-openstack-availability-zones.md
+++ b/content/post/deploying-openstack-availability-zones.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-availability-zones.jpg"
 slug = "deploying-openstack-availability-zones"
 tags = ["OpenStack"]
 title = "Deploying OpenStack Availability Zones"
+aliases = ["/deploying-openstack-availability-zones/"]
 
 +++
 

--- a/content/post/derpnstink-1.md
+++ b/content/post/derpnstink-1.md
@@ -8,6 +8,7 @@ cover = "/images/2019/05/Screen-Shot-2019-05-06-at-10.53.48-PM.png"
 slug = "derpnstink-1"
 tags = ["pentesting", "CTF", "vulnhub", "offsec", "security", "BootToRoot"]
 title = "DerpNStink: 1"
+aliases = ["/derpnstink-1/"]
 
 +++
 

--- a/content/post/devstack-as-a-testing-ground.md
+++ b/content/post/devstack-as-a-testing-ground.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/devstack2.png"
 slug = "devstack-as-a-testing-ground"
 tags = ["OpenStack"]
 title = "Devstack as a testing ground"
+aliases = ["/devstack-as-a-testing-ground/"]
 
 +++
 

--- a/content/post/extending-the-azure-batch-python-quickstart.md
+++ b/content/post/extending-the-azure-batch-python-quickstart.md
@@ -8,6 +8,7 @@ cover = "/images/2020/05/overview-of-the-azure-batch-workflow.png"
 slug = "extending-the-azure-batch-python-quickstart"
 tags = ["azure", "Python", "cloud", "batch", "exif", "gps", "automation"]
 title = "Extending the Azure Batch Python Quickstart"
+aliases = ["/extending-the-azure-batch-python-quickstart/"]
 
 +++
 

--- a/content/post/first-book-update-2018.md
+++ b/content/post/first-book-update-2018.md
@@ -8,6 +8,7 @@ cover = "/images/2018/02/best-bookstores-chicago-open-books.jpg"
 slug = "first-book-update-2018"
 tags = ["books"]
 title = "First Book Update 2018"
+aliases = ["/first-book-update-2018/"]
 
 +++
 

--- a/content/post/fnproject-and-open-source-faas.md
+++ b/content/post/fnproject-and-open-source-faas.md
@@ -8,6 +8,7 @@ cover = "/images/2017/12/Screen-Shot-2017-12-13-at-10.06.03-PM.png"
 slug = "fnproject-and-open-source-faas"
 tags = ["serverless", "faas"]
 title = "Fn Project and Open Source FaaS"
+aliases = ["/fnproject-and-open-source-faas/"]
 
 +++
 

--- a/content/post/forest.md
+++ b/content/post/forest.md
@@ -8,6 +8,7 @@ cover = "/images/2020/03/Screen-Shot-2020-03-26-at-8.48.54-PM.png"
 slug = "forest"
 tags = ["CTF", "hackthebox", "offsec", "security", "kali", "metasploit"]
 title = "Forest"
+aliases = ["/forest/"]
 
 +++
 

--- a/content/post/getting-acquainted-with-openstack-rally.md
+++ b/content/post/getting-acquainted-with-openstack-rally.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-rally.jpg"
 slug = "getting-acquainted-with-openstack-rally"
 tags = ["OpenStack", "automation"]
 title = "Getting Acquainted with OpenStack Rally"
+aliases = ["/getting-acquainted-with-openstack-rally/"]
 
 +++
 

--- a/content/post/getting-started-with-openstack.md
+++ b/content/post/getting-started-with-openstack.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/OpenStack_logo.png"
 slug = "getting-started-with-openstack"
 tags = ["Getting Started", "OpenStack"]
 title = "Getting started with OpenStack"
+aliases = ["/getting-started-with-openstack/"]
 
 +++
 

--- a/content/post/getting-started-with-terraform-on-oracle-cloud-infrastructure-oci.md
+++ b/content/post/getting-started-with-terraform-on-oracle-cloud-infrastructure-oci.md
@@ -8,6 +8,7 @@ cover = "/images/2018/10/Screen-Shot-2018-10-09-at-1.17.31-PM.png"
 slug = "getting-started-with-terraform-on-oracle-cloud-infrastructure-oci"
 tags = ["cloud", "OCI", "Getting Started", "terraform"]
 title = "Getting Started with Terraform on Oracle Cloud Infrastructure (OCI)"
+aliases = ["/getting-started-with-terraform-on-oracle-cloud-infrastructure-oci/"]
 
 +++
 

--- a/content/post/hackinos-boot-to-root.md
+++ b/content/post/hackinos-boot-to-root.md
@@ -8,6 +8,7 @@ cover = "/images/2019/04/HackInOS-00.png"
 slug = "hackinos-boot-to-root"
 tags = ["pentesting", "metasploit", "CTF", "BootToRoot", "security", "vulnhub"]
 title = "HackInOS Boot to Root"
+aliases = ["/hackinos-boot-to-root/"]
 
 +++
 

--- a/content/post/hackthebox.md
+++ b/content/post/hackthebox.md
@@ -8,6 +8,7 @@ cover = "/images/2020/01/Screen-Shot-2020-01-10-at-10.19.47-PM.png"
 slug = "hackthebox"
 tags = ["pentesting", "CTF", "kali", "metasploit", "offsec"]
 title = "HackTheBox"
+aliases = ["/hackthebox/"]
 
 +++
 

--- a/content/post/limiting-access-in-security-groups.md
+++ b/content/post/limiting-access-in-security-groups.md
@@ -8,6 +8,7 @@ cover = "/images/2017/10/scenario-1-sg-inbound-gwt.png"
 slug = "limiting-access-in-security-groups"
 tags = ["AWS"]
 title = "Limiting Access in Security Groups"
+aliases = ["/limiting-access-in-security-groups/"]
 
 +++
 

--- a/content/post/managing-dynamic-database-credentials-with-hashicorp-vault-and-chef.md
+++ b/content/post/managing-dynamic-database-credentials-with-hashicorp-vault-and-chef.md
@@ -8,6 +8,7 @@ cover = "/images/2018/01/Screen-Shot-2018-01-07-at-1.14.27-PM.png"
 slug = "managing-dynamic-database-credentials-with-hashicorp-vault-and-chef"
 tags = ["vault", "chef", "secrets", "automation", "Python", "consul"]
 title = "Managing Dynamic Database Credentials With Hashicorp Vault and Chef"
+aliases = ["/managing-dynamic-database-credentials-with-hashicorp-vault-and-chef/"]
 
 +++
 

--- a/content/post/managing-ssh-secrets-with-vault.md
+++ b/content/post/managing-ssh-secrets-with-vault.md
@@ -8,6 +8,7 @@ cover = "/images/2018/01/Screen-Shot-2018-01-03-at-1.14.50-AM.png"
 slug = "managing-ssh-secrets-with-vault"
 tags = ["vault", "secrets", "consul", "Docker", "containers"]
 title = "Managing SSH Secrets with Vault"
+aliases = ["/managing-ssh-secrets-with-vault/"]
 
 +++
 

--- a/content/post/mitigation-vs-resolution.md
+++ b/content/post/mitigation-vs-resolution.md
@@ -5,6 +5,7 @@ description = ""
 draft = true
 slug = "mitigation-vs-resolution"
 title = "Mitigation vs Resolution"
+aliases = ["/mitigation-vs-resolution/"]
 
 +++
 

--- a/content/post/netapp-over-fc-and-cinder-on-openstack-ocata.md
+++ b/content/post/netapp-over-fc-and-cinder-on-openstack-ocata.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/Cinder_netapp_Setup-300x255.png"
 slug = "netapp-over-fc-and-cinder-on-openstack-ocata"
 tags = ["OpenStack", "Storage"]
 title = "NetApp over FC and Cinder on OpenStack Ocata"
+aliases = ["/netapp-over-fc-and-cinder-on-openstack-ocata/"]
 
 +++
 

--- a/content/post/ocata-and-ipv6.md
+++ b/content/post/ocata-and-ipv6.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/ipv6-ipv4.jpg"
 slug = "ocata-and-ipv6"
 tags = ["OpenStack", "IPv6"]
 title = "Ocata and IPv6"
+aliases = ["/ocata-and-ipv6/"]
 
 +++
 

--- a/content/post/openstack-image-bootstrap-on-ipv6.md
+++ b/content/post/openstack-image-bootstrap-on-ipv6.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/glance.png"
 slug = "openstack-image-bootstrap-on-ipv6"
 tags = ["OpenStack", "IPv6"]
 title = "OpenStack image bootstrap on IPv6"
+aliases = ["/openstack-image-bootstrap-on-ipv6/"]
 
 +++
 

--- a/content/post/openstack-pike-released.md
+++ b/content/post/openstack-pike-released.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-pike.jpg"
 slug = "openstack-pike-released"
 tags = ["OpenStack"]
 title = "OpenStack Pike Released"
+aliases = ["/openstack-pike-released/"]
 
 +++
 

--- a/content/post/openstack-summit-boston-early-bird-at-the-upstream-institute.md
+++ b/content/post/openstack-summit-boston-early-bird-at-the-upstream-institute.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-summit-boston-6.jpeg"
 slug = "openstack-summit-boston-early-bird-at-the-upstream-institute"
 tags = ["OpenStack", "Python", "automation", "summit"]
 title = "OpenStack Summit Boston - Upstream Institute"
+aliases = ["/openstack-summit-boston-early-bird-at-the-upstream-institute/"]
 
 +++
 

--- a/content/post/openstack-summit-boston-monday-keynotes.md
+++ b/content/post/openstack-summit-boston-monday-keynotes.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-summit-boston-7.jpeg"
 slug = "openstack-summit-boston-monday-keynotes"
 tags = ["OpenStack", "summit"]
 title = "OpenStack Summit Boston - Monday Keynotes"
+aliases = ["/openstack-summit-boston-monday-keynotes/"]
 
 +++
 

--- a/content/post/openstack-summit-boston-monday-sessions.md
+++ b/content/post/openstack-summit-boston-monday-sessions.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-summit-boston-5.jpeg"
 slug = "openstack-summit-boston-monday-sessions"
 tags = ["OpenStack", "summit"]
 title = "OpenStack Summit Boston - Monday Sessions"
+aliases = ["/openstack-summit-boston-monday-sessions/"]
 
 +++
 

--- a/content/post/openstack-summit-boston-tuesday-keynotes.md
+++ b/content/post/openstack-summit-boston-tuesday-keynotes.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-summit-boston-4.jpeg"
 slug = "openstack-summit-boston-tuesday-keynotes"
 tags = ["OpenStack", "summit"]
 title = "OpenStack Summit Boston - Tuesday Keynotes"
+aliases = ["/openstack-summit-boston-tuesday-keynotes/"]
 
 +++
 

--- a/content/post/openstack-summit-boston-tuesday-sessions-am.md
+++ b/content/post/openstack-summit-boston-tuesday-sessions-am.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-summit-boston-3.jpeg"
 slug = "openstack-summit-boston-tuesday-sessions-am"
 tags = ["OpenStack", "summit"]
 title = "OpenStack Summit Boston - Tuesday Sessions AM"
+aliases = ["/openstack-summit-boston-tuesday-sessions-am/"]
 
 +++
 

--- a/content/post/openstack-summit-boston-tuesday-sessions-pm.md
+++ b/content/post/openstack-summit-boston-tuesday-sessions-pm.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-summit-boston-2.jpeg"
 slug = "openstack-summit-boston-tuesday-sessions-pm"
 tags = ["OpenStack", "summit"]
 title = "OpenStack Summit Boston - Tuesday Sessions PM"
+aliases = ["/openstack-summit-boston-tuesday-sessions-pm/"]
 
 +++
 

--- a/content/post/openstack-summit-boston-wednesday-sessions-am.md
+++ b/content/post/openstack-summit-boston-wednesday-sessions-am.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-summit-boston-1.jpeg"
 slug = "openstack-summit-boston-wednesday-sessions-am"
 tags = ["OpenStack", "summit"]
 title = "OpenStack Summit Boston - Wednesday Sessions AM"
+aliases = ["/openstack-summit-boston-wednesday-sessions-am/"]
 
 +++
 

--- a/content/post/openstack-summit-boston-wednesday-sessions-pm.md
+++ b/content/post/openstack-summit-boston-wednesday-sessions-pm.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-summit-boston.jpeg"
 slug = "openstack-summit-boston-wednesday-sessions-pm"
 tags = ["OpenStack", "summit"]
 title = "OpenStack Summit Boston - Wednesday Sessions PM"
+aliases = ["/openstack-summit-boston-wednesday-sessions-pm/"]
 
 +++
 

--- a/content/post/packet-captures-and-dns.md
+++ b/content/post/packet-captures-and-dns.md
@@ -8,6 +8,7 @@ cover = "/images/2019/05/wireshark-logo.jpg"
 slug = "packet-captures-and-dns"
 tags = ["DNS", "pcap", "wireshark", "tshark", "tcpdump", "network"]
 title = "Packet Captures and DNS"
+aliases = ["/packet-captures-and-dns/"]
 
 +++
 
@@ -222,6 +223,7 @@ title = "Packet Captures and DNS"
     <ul>
         <li><a class="attachment" href="https://wiki.wireshark.org/SampleCaptures?action=AttachFile&amp;do=get&amp;target=dhcp-and-dyndns.pcap.gz"
                 title="">dhcp-and-dyndns.pcap.gz</a> <span >&nbsp;(libpcap) A sample session of a host doing dhcp first and then dyndns.</span></li>
+aliases = ["/packet-captures-and-dns/"]
         <li><span ><a title="" href="https://wiki.wireshark.org/SampleCaptures?action=AttachFile&amp;do=get&amp;target=dns.cap" class="attachment">dns.cap</a><span >&nbsp;(libpcap) Various DNS lookups.</span><br
             /></span>
         </li>

--- a/content/post/penetration-testing-for-newbies.md
+++ b/content/post/penetration-testing-for-newbies.md
@@ -8,6 +8,7 @@ cover = "/images/2018/11/2018-11-29_22-39-05.png"
 slug = "penetration-testing-for-newbies"
 tags = ["pentesting", "security", "metasploit", "kali", "Getting Started"]
 title = "Penetration Testing for Newbies"
+aliases = ["/penetration-testing-for-newbies/"]
 
 +++
 

--- a/content/post/placement-api-and-cells-in-ocata.md
+++ b/content/post/placement-api-and-cells-in-ocata.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/openstack-ocata-cells.jpg"
 slug = "placement-api-and-cells-in-ocata"
 tags = ["OpenStack"]
 title = "Placement API and Cells in Ocata"
+aliases = ["/placement-api-and-cells-in-ocata/"]
 
 +++
 

--- a/content/post/preparing-to-run-openstack-in-nomad.md
+++ b/content/post/preparing-to-run-openstack-in-nomad.md
@@ -8,6 +8,7 @@ cover = "/images/2017/09/nomad-logo.jpg"
 slug = "preparing-to-run-openstack-in-nomad"
 tags = ["OpenStack", "containers"]
 title = "Preparing to Run OpenStack in Nomad"
+aliases = ["/preparing-to-run-openstack-in-nomad/"]
 
 +++
 

--- a/content/post/python-flask-and-mongo-part-2.md
+++ b/content/post/python-flask-and-mongo-part-2.md
@@ -8,6 +8,7 @@ cover = "/images/2017/10/Screen-Shot-2017-10-14-at-5.16.25-PM.png"
 slug = "python-flask-and-mongo-part-2"
 tags = ["Python", "Udemy"]
 title = "Python, Flask, and Mongo, Part 2"
+aliases = ["/python-flask-and-mongo-part-2/"]
 
 +++
 

--- a/content/post/python-flask-and-mongo.md
+++ b/content/post/python-flask-and-mongo.md
@@ -8,6 +8,7 @@ cover = "/images/2017/10/big-o-cheatsheet.jpg"
 slug = "python-flask-and-mongo"
 tags = ["Python", "Udemy"]
 title = "Python, Flask, and Mongo"
+aliases = ["/python-flask-and-mongo/"]
 
 +++
 

--- a/content/post/python-openstackclient-dependency-problems-on-mac-os-x.md
+++ b/content/post/python-openstackclient-dependency-problems-on-mac-os-x.md
@@ -8,6 +8,7 @@ cover = "https://imgs.xkcd.com/comics/dependencies.png"
 slug = "python-openstackclient-dependency-problems-on-mac-os-x"
 tags = ["OpenStack", "Python"]
 title = "Python-OpenStackclient Dependency Problems on MacOS"
+aliases = ["/python-openstackclient-dependency-problems-on-mac-os-x/"]
 
 +++
 

--- a/content/post/recovering-a-failed-controller-node.md
+++ b/content/post/recovering-a-failed-controller-node.md
@@ -8,6 +8,7 @@ cover = "/images/2017/08/operation-3.jpg"
 slug = "recovering-a-failed-controller-node"
 tags = ["OpenStack"]
 title = "Recovering a Failed Controller Node"
+aliases = ["/recovering-a-failed-controller-node/"]
 
 +++
 

--- a/content/post/terraform-up-and-running-2nd-edition-remix-to-ignition.md
+++ b/content/post/terraform-up-and-running-2nd-edition-remix-to-ignition.md
@@ -5,6 +5,7 @@ description = ""
 draft = true
 slug = "terraform-up-and-running-2nd-edition-remix-to-ignition"
 title = "Terraform Up and Running (2nd edition)"
+aliases = ["/terraform-up-and-running-2nd-edition-remix-to-ignition/"]
 
 +++
 

--- a/content/post/the-kubernetes-book.md
+++ b/content/post/the-kubernetes-book.md
@@ -8,6 +8,7 @@ cover = "/images/2017/11/Screen-Shot-2017-11-12-at-6.22.27-PM.png"
 slug = "the-kubernetes-book"
 tags = ["kubernetes", "books", "containers"]
 title = "The Kubernetes Book"
+aliases = ["/the-kubernetes-book/"]
 
 +++
 

--- a/content/post/tinyurls-in-python.md
+++ b/content/post/tinyurls-in-python.md
@@ -5,6 +5,7 @@ description = ""
 draft = true
 slug = "tinyurls-in-python"
 title = "TinyURLs in Python"
+aliases = ["/tinyurls-in-python/"]
 
 +++
 

--- a/content/post/troubleshooting-a-slow-client.md
+++ b/content/post/troubleshooting-a-slow-client.md
@@ -8,6 +8,7 @@ cover = "/images/2018/12/golang-debug-1.png"
 slug = "troubleshooting-a-slow-client"
 tags = ["golang", "AWS", "IPv6", "IPv4", "network", "HTTP", "API"]
 title = "Troubleshooting a Slow API Client in Golang"
+aliases = ["/troubleshooting-a-slow-client/"]
 
 +++
 

--- a/content/post/troubleshooting-openstack.md
+++ b/content/post/troubleshooting-openstack.md
@@ -8,6 +8,7 @@ cover = "/images/2017/10/COMPUTER-REPAIR.jpg"
 slug = "troubleshooting-openstack"
 tags = ["OpenStack"]
 title = "Troubleshooting OpenStack"
+aliases = ["/troubleshooting-openstack/"]
 
 +++
 

--- a/content/post/using-jenkins-and-aws-to-build-and-push-docker-images.md
+++ b/content/post/using-jenkins-and-aws-to-build-and-push-docker-images.md
@@ -8,6 +8,7 @@ cover = "/images/2017/12/docker-jenkins.png"
 slug = "using-jenkins-and-aws-to-build-and-push-docker-images"
 tags = ["containers", "jenkins", "AWS", "Docker", "CI"]
 title = "Using Jenkins and AWS to Build and Push Docker Images"
+aliases = ["/using-jenkins-and-aws-to-build-and-push-docker-images/"]
 
 +++
 

--- a/content/post/wallabys-nightmare-1-02.md
+++ b/content/post/wallabys-nightmare-1-02.md
@@ -8,6 +8,7 @@ cover = "/images/2019/05/Screen-Shot-2019-05-05-at-9.39.23-AM.png"
 slug = "wallabys-nightmare-1-02"
 tags = ["CTF", "vulnhub", "pentesting", "security", "BootToRoot", "offsec"]
 title = "Wallaby's: Nightmare (v1.0.2)"
+aliases = ["/wallabys-nightmare-1-02/"]
 
 +++
 

--- a/content/post/why-i-sold-off-my-home-lab.md
+++ b/content/post/why-i-sold-off-my-home-lab.md
@@ -6,6 +6,7 @@ draft = false
 cover = "/images/2018/09/homelab.jpg"
 slug = "why-i-sold-off-my-home-lab"
 title = "Why I sold off my home lab"
+aliases = ["/why-i-sold-off-my-home-lab/"]
 
 +++
 


### PR DESCRIPTION
for all markdown files (posts) add an alias line so it is reachable with the URL path from ghost. This will make all my old posts on twitter and linked route to the correct post within hugo